### PR TITLE
CP-9682 - Swap documents and fields list containers layout

### DIFF
--- a/app/javascript/application.scss
+++ b/app/javascript/application.scss
@@ -109,6 +109,10 @@ button[disabled] .enabled {
   @apply select base-input w-full font-normal;
 }
 
+:root {
+  --tooltip-color: black;
+}
+
 .tooltip-bottom-end:before {
   transform: translateX(-95%);
   top: var(--tooltip-offset);


### PR DESCRIPTION
CP-9682

# Overview
Improve UI flow by moving fields list to the left side and documents preview to the right side.

# Screenshot
<img width="1608" height="927" alt="Screenshot 2025-07-16 at 12 57 20 PM" src="https://github.com/user-attachments/assets/6420a10a-d4d5-429b-862b-6f7e8cccc719" />
