### PR TITLE
CP-9771 - Comment out certain field types

### DIFF
--- a/app/javascript/template_builder/fields.vue
+++ b/app/javascript/template_builder/fields.vue
@@ -112,7 +112,7 @@
       :key="type"
     >
       <button
-        v-if="fieldTypes.includes(type) || ((withPhone || type != 'phone') && (withPayment || type != 'payment') && (withVerification || type != 'verification'))"
+        v-if="fieldTypes.includes(type) || ((withPhone || type != 'phone') && (withPayment || type != 'payment') && (withVerification || type != 'verification') && !['stamp', 'cells', 'file', 'image', 'number', 'initials'].includes(type))"
         :id="`${type}_type_field_button`"
         draggable="true"
         class="field-type-button group flex items-center justify-center border border-dashed w-full rounded relative fields-grid-item"

--- a/app/javascript/template_builder/fields.vue
+++ b/app/javascript/template_builder/fields.vue
@@ -112,7 +112,7 @@
       :key="type"
     >
       <button
-        v-if="fieldTypes.includes(type) || ((withPhone || type != 'phone') && (withPayment || type != 'payment') && (withVerification || type != 'verification') && !['stamp', 'cells', 'file', 'image', 'number', 'initials'].includes(type))"
+        v-if="fieldTypes.includes(type) || ((withPhone || type != 'phone') && (withPayment || type != 'payment') && (withVerification || type != 'verification') && !['stamp', 'cells', 'file', 'image', 'number'].includes(type))"
         :id="`${type}_type_field_button`"
         draggable="true"
         class="field-type-button group flex items-center justify-center border border-dashed w-full rounded relative fields-grid-item"

--- a/spec/factories/templates.rb
+++ b/spec/factories/templates.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
       submitter_count { 1 }
       attachment_count { 1 }
       only_field_types do
-        %w[text date checkbox radio signature number multiple select initials image file stamp cells phone payment]
+        %w[text date checkbox radio signature multiple select phone payment]
       end
       except_field_types { [] }
       private_access_user { nil }

--- a/spec/system/signing_form_spec.rb
+++ b/spec/system/signing_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Signing Form' do
 
   context 'when the template form link is opened' do
     let(:template) do
-      create(:template, shared_link: true, account:, author:, except_field_types: %w[phone payment stamp])
+      create(:template, shared_link: true, account:, author:, except_field_types: %w[phone payment])
     end
 
     before do
@@ -45,9 +45,6 @@ RSpec.describe 'Signing Form' do
       draw_canvas
       click_button 'next'
 
-      # Number step
-      fill_in 'House number', with: '123'
-      click_button 'next'
 
       # Multiple choice step
       %w[Red Blue].each { |color| check color }
@@ -57,22 +54,6 @@ RSpec.describe 'Signing Form' do
       select 'Male', from: 'Gender'
       click_button 'next'
 
-      # Initials step
-      draw_canvas
-      click_button 'next'
-
-      # Image step
-      find('#dropzone').click
-      find('input[type="file"]', visible: false).attach_file(Rails.root.join('spec/fixtures/sample-image.png'))
-      click_button 'next'
-
-      # File step
-      find('#dropzone').click
-      find('input[type="file"]', visible: false).attach_file(Rails.root.join('spec/fixtures/sample-document.pdf'))
-      click_button 'next'
-
-      # Cell step
-      fill_in 'Cell code', with: '123'
       click_on 'Complete'
 
       expect(page).to have_button('Download')
@@ -92,18 +73,13 @@ RSpec.describe 'Signing Form' do
       expect(field_value(submitter, 'Do you agree?')).to be_truthy
       expect(field_value(submitter, 'First child')).to eq 'Boy'
       expect(field_value(submitter, 'Signature')).to be_present
-      expect(field_value(submitter, 'House number')).to eq 123
       expect(field_value(submitter, 'Colors')).to contain_exactly('Red', 'Blue')
       expect(field_value(submitter, 'Gender')).to eq 'Male'
-      expect(field_value(submitter, 'Initials')).to be_present
-      expect(field_value(submitter, 'Avatar')).to be_present
-      expect(field_value(submitter, 'Attachment')).to be_present
-      expect(field_value(submitter, 'Cell code')).to eq '123'
     end
   end
 
   context 'when the submitter form link is opened' do
-    let(:template) { create(:template, account:, author:, except_field_types: %w[phone payment stamp]) }
+    let(:template) { create(:template, account:, author:, except_field_types: %w[phone payment]) }
     let(:submission) { create(:submission, template:) }
     let(:submitter) do
       create(:submitter, submission:, uuid: template.submitters.first['uuid'], account:, email: 'robin@example.com')
@@ -134,9 +110,6 @@ RSpec.describe 'Signing Form' do
       draw_canvas
       click_button 'next'
 
-      # Number step
-      fill_in 'House number', with: '123'
-      click_button 'next'
 
       # Multiple choice step
       %w[Red Blue].each { |color| check color }
@@ -146,22 +119,6 @@ RSpec.describe 'Signing Form' do
       select 'Male', from: 'Gender'
       click_button 'next'
 
-      # Initials step
-      draw_canvas
-      click_button 'next'
-
-      # Image step
-      find('#dropzone').click
-      find('input[type="file"]', visible: false).attach_file(Rails.root.join('spec/fixtures/sample-image.png'))
-      click_button 'next'
-
-      # File step
-      find('#dropzone').click
-      find('input[type="file"]', visible: false).attach_file(Rails.root.join('spec/fixtures/sample-document.pdf'))
-      click_button 'next'
-
-      # Cell step
-      fill_in 'Cell code', with: '123'
       click_on 'Complete'
 
       expect(page).to have_button('Download')
@@ -181,13 +138,8 @@ RSpec.describe 'Signing Form' do
       expect(field_value(submitter, 'Do you agree?')).to be_truthy
       expect(field_value(submitter, 'First child')).to eq 'Boy'
       expect(field_value(submitter, 'Signature')).to be_present
-      expect(field_value(submitter, 'House number')).to eq 123
       expect(field_value(submitter, 'Colors')).to contain_exactly('Red', 'Blue')
       expect(field_value(submitter, 'Gender')).to eq 'Male'
-      expect(field_value(submitter, 'Initials')).to be_present
-      expect(field_value(submitter, 'Avatar')).to be_present
-      expect(field_value(submitter, 'Attachment')).to be_present
-      expect(field_value(submitter, 'Cell code')).to eq '123'
     end
   end
 
@@ -390,32 +342,6 @@ RSpec.describe 'Signing Form' do
     end
   end
 
-  context 'when the number step' do
-    let(:template) { create(:template, account:, author:, only_field_types: %w[number]) }
-    let(:submission) { create(:submission, template:) }
-    let(:submitter) do
-      create(:submitter, submission:, uuid: template.submitters.first['uuid'], account:)
-    end
-
-    it 'completes the form if the field is filled' do
-      visit submit_form_path(slug: submitter.slug)
-
-      input = find_field('House number')
-
-      expect(input[:required]).to be_truthy
-      expect(input[:placeholder]).to eq 'Type here...'
-
-      fill_in 'House number', with: '4'
-      click_button 'Complete'
-
-      expect(page).to have_content('Form has been completed!')
-
-      submitter.reload
-
-      expect(submitter.completed_at).to be_present
-      expect(field_value(submitter, 'House number')).to eq 4
-    end
-  end
 
   context 'when the multiple choice step' do
     let(:template) { create(:template, account:, author:, only_field_types: %w[multiple]) }
@@ -462,138 +388,9 @@ RSpec.describe 'Signing Form' do
     end
   end
 
-  context 'when the initials step' do
-    let(:template) { create(:template, account:, author:, only_field_types: %w[initials]) }
-    let(:submission) { create(:submission, template:) }
-    let(:submitter) do
-      create(:submitter, submission:, uuid: template.submitters.first['uuid'], account:)
-    end
 
-    it 'completes the form if the canvas is typed' do
-      visit submit_form_path(slug: submitter.slug)
 
-      find('#expand_form_button').click
-      fill_in 'initials_text_input', with: 'John Doe'
-      click_button 'Complete'
 
-      expect(page).to have_content('Document has been signed!')
-
-      submitter.reload
-
-      expect(submitter.completed_at).to be_present
-      expect(field_value(submitter, 'Initials')).to be_present
-    end
-
-    it 'completes the form if the canvas is drawn' do
-      visit submit_form_path(slug: submitter.slug)
-
-      find('#expand_form_button').click
-      click_link 'Draw'
-      draw_canvas
-      click_button 'Complete'
-
-      expect(page).to have_content('Document has been signed!')
-
-      submitter.reload
-
-      expect(submitter.completed_at).to be_present
-      expect(field_value(submitter, 'Initials')).to be_present
-    end
-
-    it 'completes the form if the initials is uploaded' do
-      visit submit_form_path(slug: submitter.slug)
-
-      find('#expand_form_button').click
-      find('span[data-tip="Click to upload"]').click
-      find('input[type="file"]', visible: false).attach_file(Rails.root.join('spec/fixtures/sample-image.png'))
-
-      sleep 0.1
-
-      click_button 'Complete'
-
-      expect(page).to have_content('Document has been signed!')
-
-      submitter.reload
-
-      expect(submitter.completed_at).to be_present
-      expect(field_value(submitter, 'Initials')).to be_present
-    end
-  end
-
-  context 'when the image step' do
-    let(:template) { create(:template, account:, author:, only_field_types: %w[image]) }
-    let(:submission) { create(:submission, template:) }
-    let(:submitter) do
-      create(:submitter, submission:, uuid: template.submitters.first['uuid'], account:)
-    end
-
-    it 'completes the form if the image is uploaded' do
-      visit submit_form_path(slug: submitter.slug)
-
-      find('#expand_form_button').click
-      find('#dropzone').click
-      find('input[type="file"]', visible: false).attach_file(Rails.root.join('spec/fixtures/sample-image.png'))
-      click_button 'Complete'
-
-      expect(page).to have_content('Form has been completed!')
-
-      submitter.reload
-
-      expect(submitter.completed_at).to be_present
-      expect(field_value(submitter, 'Avatar')).to be_present
-    end
-  end
-
-  context 'when the file step' do
-    let(:template) { create(:template, account:, author:, only_field_types: %w[file]) }
-    let(:submission) { create(:submission, template:) }
-    let(:submitter) do
-      create(:submitter, submission:, uuid: template.submitters.first['uuid'], account:)
-    end
-
-    it 'completes the form if the file is uploaded' do
-      visit submit_form_path(slug: submitter.slug)
-
-      find('#expand_form_button').click
-      find('#dropzone').click
-      find('input[type="file"]', visible: false).attach_file(Rails.root.join('spec/fixtures/sample-document.pdf'))
-      click_button 'Complete'
-
-      expect(page).to have_content('Form has been completed!')
-
-      submitter.reload
-
-      expect(submitter.completed_at).to be_present
-      expect(field_value(submitter, 'Attachment')).to be_present
-    end
-  end
-
-  context 'when the cells step' do
-    let(:template) { create(:template, account:, author:, only_field_types: %w[cells]) }
-    let(:submission) { create(:submission, template:) }
-    let(:submitter) do
-      create(:submitter, submission:, uuid: template.submitters.first['uuid'], account:)
-    end
-
-    it 'completes the form if the field is filled' do
-      visit submit_form_path(slug: submitter.slug)
-
-      input = find_field('Cell code')
-
-      expect(input[:required]).to be_truthy
-      expect(input[:placeholder]).to eq 'Type here...'
-
-      fill_in 'Cell code', with: '456'
-      click_button 'Complete'
-
-      expect(page).to have_content('Form has been completed!')
-
-      submitter.reload
-
-      expect(submitter.completed_at).to be_present
-      expect(field_value(submitter, 'Cell code')).to eq '456'
-    end
-  end
 
   context 'when the field with conditions' do
     let(:template) { create(:template, account:, author:, only_field_types: ['text']) }


### PR DESCRIPTION
CP-9771

# Overview
Refine the condition for displaying field type buttons to exclude specific types ('stamp', 'cells', 'file', 'image', 'number', 'initials') from being shown since we don't support them (yet).

## Screenshot
<img width="360" height="455" alt="Screenshot 2025-07-28 at 12 47 20 PM" src="https://github.com/user-attachments/assets/2f0913d6-1ac1-4870-8ba3-ab465058a502" />
