### PR TITLE
CP-10759 - Exclude unused fields in dropdown edit

### DIFF
--- a/app/javascript/template_builder/builder.vue
+++ b/app/javascript/template_builder/builder.vue
@@ -389,6 +389,7 @@ export default {
       withPhone: this.withPhone,
       withVerification: this.withVerification,
       withPayment: this.withPayment,
+      withStamp: this.withStamp,
       isPaymentConnected: this.isPaymentConnected,
       withFormula: this.withFormula,
       withConditions: this.withConditions,
@@ -584,6 +585,11 @@ export default {
       default: null
     },
     withPayment: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    withStamp: {
       type: Boolean,
       required: false,
       default: false

--- a/app/javascript/template_builder/builder.vue
+++ b/app/javascript/template_builder/builder.vue
@@ -389,7 +389,6 @@ export default {
       withPhone: this.withPhone,
       withVerification: this.withVerification,
       withPayment: this.withPayment,
-      withStamp: this.withStamp,
       isPaymentConnected: this.isPaymentConnected,
       withFormula: this.withFormula,
       withConditions: this.withConditions,
@@ -585,11 +584,6 @@ export default {
       default: null
     },
     withPayment: {
-      type: Boolean,
-      required: false,
-      default: false
-    },
-    withStamp: {
       type: Boolean,
       required: false,
       default: false

--- a/app/javascript/template_builder/field_settings.vue
+++ b/app/javascript/template_builder/field_settings.vue
@@ -290,7 +290,7 @@
     </label>
   </div>
   <li
-    v-if="withRequired && field.type !== 'phone' && field.type !== 'stamp' && field.type !== 'verification'"
+    v-if="withRequired && field.type !== 'phone' && field.type !== 'stamp' && field.type !== 'verification' && field.type !== 'cells'"
     @click.stop
   >
     <label class="cursor-pointer py-1.5">

--- a/app/javascript/template_builder/field_type.vue
+++ b/app/javascript/template_builder/field_type.vue
@@ -55,7 +55,7 @@ import { IconTextSize, IconWritingSign, IconCalendarEvent, IconPhoto, IconCheckb
 
 export default {
   name: 'FiledTypeDropdown',
-  inject: ['withPhone', 'withPayment', 'withVerification', 'withStamp', 't', 'fieldTypes'],
+  inject: ['withPhone', 'withPayment', 'withVerification', 't', 'fieldTypes'],
   props: {
     modelValue: {
       type: String,

--- a/app/javascript/template_builder/field_type.vue
+++ b/app/javascript/template_builder/field_type.vue
@@ -30,7 +30,7 @@
         v-for="(icon, type) in fieldIconsSorted"
         :key="type"
       >
-        <li v-if="fieldTypes.includes(type) || ((withPhone || type != 'phone') && (withPayment || type != 'payment') && (withVerification || type != 'verification'))">
+        <li v-if="['text', 'signature', 'initials', 'date', 'checkbox', 'multiple', 'radio', 'select'].includes(type)">
           <a
             href="#"
             class="text-sm py-1 px-2"
@@ -55,7 +55,7 @@ import { IconTextSize, IconWritingSign, IconCalendarEvent, IconPhoto, IconCheckb
 
 export default {
   name: 'FiledTypeDropdown',
-  inject: ['withPhone', 'withPayment', 'withVerification', 't', 'fieldTypes'],
+  inject: ['withPhone', 'withPayment', 'withVerification', 'withStamp', 't', 'fieldTypes'],
   props: {
     modelValue: {
       type: String,


### PR DESCRIPTION
CP-10759

# Overview
This removes the fields we don't currently support from the dropdown that I didn't know existed when I first worked on this.

## Screenshot
After:
<img width="595" height="495" alt="Screenshot 2025-08-28 at 12 36 01 PM" src="https://github.com/user-attachments/assets/cc419982-6311-4545-9a1f-03c7736bd85e" />

Before:
<img width="450" height="516" alt="Screenshot 2025-08-28 at 12 09 20 PM" src="https://github.com/user-attachments/assets/83629649-7dba-4bcc-9851-c71c37bc87e6" />

