### PR TITLE
fix migration 20250924174100_rename_account_groups_to_partnerships.rb

### DIFF
--- a/db/migrate/20250924174100_rename_account_groups_to_partnerships.rb
+++ b/db/migrate/20250924174100_rename_account_groups_to_partnerships.rb
@@ -6,7 +6,9 @@ class RenameAccountGroupsToPartnerships < ActiveRecord::Migration[8.0]
     # Rename the foreign key columns in other tables
     rename_column :templates, :account_group_id, :partnership_id
     rename_column :template_folders, :account_group_id, :partnership_id
-    rename_column :export_locations, :global_account_group_id, :global_partnership_id
+
+    # Add global_partnership_id to export_locations
+    add_column :export_locations, :global_partnership_id, :integer
 
     # Remove partnership relationships since both users and accounts use API context now
     remove_column :users, :account_group_id, :bigint


### PR DESCRIPTION
Hotfix for migration that did not run correctly in CloudFormation.