### PR TITLE
CP-12658 docuseal status 2

### DIFF
--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -190,7 +190,7 @@ module Api
     def submissions_params
       permitted_attrs = [
         :send_email, :send_sms, :bcc_completed, :completed_redirect_url, :reply_to, :go_to_last,
-        :expire_at, :name, :external_account_id,
+        :expire_at, :name, :external_account_id, :requires_approval,
         {
           message: %i[subject body],
           submitters: [[:send_email, :send_sms, :completed_redirect_url, :uuid, :name, :email, :role,

--- a/app/controllers/api/submitters_approve_controller.rb
+++ b/app/controllers/api/submitters_approve_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Api
+  class SubmittersApproveController < ApiBaseController
+    before_action :load_submitter
+
+    def approve
+      submission = @submitter.submission
+
+      submission.update!(approved_at: Time.current) unless submission.approved_at?
+
+      render json: Submitters::SerializeForApi.call(@submitter), status: :ok
+    end
+
+    private
+
+    def load_submitter
+      @submitter = Submitter.find_by!(slug: params[:slug])
+      authorize! :read, @submitter
+    end
+  end
+end

--- a/app/controllers/api/submitters_request_changes_controller.rb
+++ b/app/controllers/api/submitters_request_changes_controller.rb
@@ -12,6 +12,7 @@ module Api
       unless @submitter.changes_requested_at?
         ApplicationRecord.transaction do
           @submitter.update!(changes_requested_at: Time.current, completed_at: nil)
+          @submitter.submission.update!(approved_at: nil)
 
           SubmissionEvents.create_with_tracking_data(
             @submitter,

--- a/app/jobs/process_submitter_completion_job.rb
+++ b/app/jobs/process_submitter_completion_job.rb
@@ -80,10 +80,11 @@ class ProcessSubmitterCompletionJob
                                                          'webhook_url_id' => webhook.id)
       end
 
-      if webhook.events.include?('submission.completed') && is_all_completed
-        SendSubmissionCompletedWebhookRequestJob.perform_async('submission_id' => submitter.submission_id,
-                                                               'webhook_url_id' => webhook.id)
-      end
+      next unless webhook.events.include?('submission.completed') && is_all_completed &&
+                  !submitter.submission.requires_approval?
+
+      SendSubmissionCompletedWebhookRequestJob.perform_async('submission_id' => submitter.submission_id,
+                                                             'webhook_url_id' => webhook.id)
     end
   end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -82,7 +82,7 @@ class Account < ApplicationRecord
 
     webhook_urls.create!(
       url: ENV.fetch('CAREERPLUG_WEBHOOK_URL'),
-      events: %w[form.viewed form.started form.completed form.declined template.preferences_updated],
+      events: %w[form.started form.completed submission.completed form.changes_requested template.preferences_updated],
       secret: { 'X-CareerPlug-Secret' => ENV.fetch('CAREERPLUG_WEBHOOK_SECRET') }
     )
   end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -28,6 +28,7 @@
 #  index_submissions_on_account_id_and_id                           (account_id,id)
 #  index_submissions_on_account_id_and_template_id_and_id           (account_id,template_id,id) WHERE (archived_at IS NULL)
 #  index_submissions_on_account_id_and_template_id_and_id_archived  (account_id,template_id,id) WHERE (archived_at IS NOT NULL)
+#  index_submissions_on_approved_at                                 (approved_at)
 #  index_submissions_on_created_by_user_id                          (created_by_user_id)
 #  index_submissions_on_slug                                        (slug) UNIQUE
 #  index_submissions_on_template_id                                 (template_id)

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -5,10 +5,12 @@
 # Table name: submissions
 #
 #  id                  :bigint           not null, primary key
+#  approved_at         :datetime
 #  archived_at         :datetime
 #  expire_at           :datetime
 #  name                :text
 #  preferences         :text             not null
+#  requires_approval   :boolean          default(FALSE), not null
 #  slug                :string           not null
 #  source              :string           not null
 #  submitters_order    :string           not null

--- a/app/models/submitter.rb
+++ b/app/models/submitter.rb
@@ -136,8 +136,8 @@ class Submitter < ApplicationRecord
   end
 
   def export_submission_on_status_change
-    status_fields = %w[completed_at declined_at opened_at sent_at]
-    return unless saved_changes.keys.intersect?(status_fields)
+    # status_fields = %w[completed_at declined_at opened_at sent_at]
+    # return unless saved_changes.keys.intersect?(status_fields)
 
     # CP-12761: Disabled - migrating to webhooks. Remove when ATS /api/docuseal/submissions endpoint is cleaned up.
     # ExportSubmissionService.new(submission).call

--- a/app/models/submitter.rb
+++ b/app/models/submitter.rb
@@ -139,7 +139,8 @@ class Submitter < ApplicationRecord
     status_fields = %w[completed_at declined_at opened_at sent_at]
     return unless saved_changes.keys.intersect?(status_fields)
 
-    ExportSubmissionService.new(submission).call
+    # CP-12761: Disabled - migrating to webhooks. Remove when ATS /api/docuseal/submissions endpoint is cleaned up.
+    # ExportSubmissionService.new(submission).call
   rescue StandardError => e
     Rails.logger.error("Failed to export submission on status change: #{e.message}")
   end

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -159,13 +159,6 @@
                 </span>
               </div>
             <% end %>
-            <% if signed_in? && submitter && submitter.completed_at? && !submitter.declined_at? && !submitter.changes_requested_at? && current_user == @submission.template.author %>
-              <div class="mt-2 mb-1">
-                <%= link_to 'Request Changes', request_changes_submitter_path(submitter.slug),
-                            class: 'btn btn-sm btn-warning w-full',
-                            data: { turbo_frame: :modal } %>
-              </div>
-            <% end %>
           </div>
         </div>
         <div class="px-1.5 mb-4">

--- a/config/locales/i18n.yml
+++ b/config/locales/i18n.yml
@@ -783,6 +783,7 @@ en: &en
     view_form_by_html: '<b>Form viewed</b> by %{submitter_name}'
     invite_party_by_html: '<b>Invited</b> %{invited_submitter_name} by %{submitter_name}'
     complete_form_by_html: '<b>Submission completed</b> by %{submitter_name}'
+    form_update_by_html: '<b>Form updated</b> by %{submitter_name}'
     request_changes_by_html: '<b>Changes requested</b> for %{submitter_name}'
     start_verification_by_html: '<b>Identity verification started</b> by %{submitter_name}'
     complete_verification_by_html: '<b>Identity verification completed</b> by %{submitter_name} with %{provider}'
@@ -1626,6 +1627,7 @@ es: &es
     view_form_by_html: '<b>Formulario visto</b> por %{submitter_name}'
     invite_party_by_html: '<b>Invitado</b> %{invited_submitter_name} por %{submitter_name}'
     complete_form_by_html: '<b>Envío completado</b> por %{submitter_name}'
+    form_update_by_html: '<b>Formulario actualizado</b> por %{submitter_name}'
     request_changes_by_html: '<b>Cambios solicitados</b> para %{submitter_name}'
     api_complete_form_by_html: '<b>Envío completado vía API</b> por %{submitter_name}'
     start_verification_by_html: '<b>Verificación de identidad iniciada</b> por %{submitter_name}'
@@ -2461,6 +2463,7 @@ it: &it
     view_form_by_html: '<b>Modulo visualizzato</b> da %{submitter_name}'
     invite_party_by_html: '<b>Invitato</b> %{invited_submitter_name} da %{submitter_name}'
     complete_form_by_html: '<b>Invio completato</b> da %{submitter_name}'
+    form_update_by_html: '<b>Modulo aggiornato</b> da %{submitter_name}'
     api_complete_form_by_html: '<b>Invio completato tramite API</b> da %{submitter_name}'
     start_verification_by_html: "<b>Verifica dell'identità iniziata</b> da %{submitter_name}"
     complete_verification_by_html: "<b>Verifica dell'identità completata</b> da %{submitter_name} con %{provider}"
@@ -3298,6 +3301,7 @@ fr: &fr
     view_form_by_html: '<b>Formulaire consulté</b> par %{submitter_name}'
     invite_party_by_html: '<b>Invité</b> %{invited_submitter_name} par %{submitter_name}'
     complete_form_by_html: '<b>Soumission terminée</b> par %{submitter_name}'
+    form_update_by_html: '<b>Formulaire mis à jour</b> par %{submitter_name}'
     start_verification_by_html: "<b>Vérification d'identité commencée</b> par %{submitter_name}"
     complete_verification_by_html: "<b>Vérification d'identité terminée</b> par %{submitter_name} avec %{provider}"
     api_complete_form_by_html: "<b>Soumission terminée via l'API</b> par %{submitter_name}"
@@ -4134,6 +4138,7 @@ pt: &pt
     view_form_by_html: '<b>Formulário visualizado</b> por %{submitter_name}'
     invite_party_by_html: '<b>Convidado</b> %{invited_submitter_name} por %{submitter_name}'
     complete_form_by_html: '<b>Submissão concluída</b> por %{submitter_name}'
+    form_update_by_html: '<b>Formulário atualizado</b> por %{submitter_name}'
     start_verification_by_html: '<b>Verificação de identidade iniciada</b> por %{submitter_name}'
     complete_verification_by_html: '<b>Verificação de identidade concluída</b> por %{submitter_name} com %{provider}'
     api_complete_form_by_html: '<b>Submissão concluída via API</b> por %{submitter_name}'
@@ -4971,6 +4976,7 @@ de: &de
     view_form_by_html: '<b>Formular angesehen</b> von %{submitter_name}'
     invite_party_by_html: '<b>Eingeladen</b> %{invited_submitter_name} von %{submitter_name}'
     complete_form_by_html: '<b>Einreichung abgeschlossen</b> von %{submitter_name}'
+    form_update_by_html: '<b>Formular aktualisiert</b> von %{submitter_name}'
     start_verification_by_html: '<b>Identitätsüberprüfung gestartet</b> von %{submitter_name}'
     complete_verification_by_html: '<b>Identitätsüberprüfung abgeschlossen</b> von %{submitter_name} mit %{provider}'
     api_complete_form_by_html: '<b>Einreichung über API abgeschlossen</b> von %{submitter_name}'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
     resources :submitters, only: [], param: :slug do
       member do
         post :request_changes, controller: 'submitters_request_changes'
+        post :approve, controller: 'submitters_approve'
       end
     end
     resources :submissions, only: %i[index show create destroy] do

--- a/db/migrate/20260311000001_add_requires_approval_to_submissions.rb
+++ b/db/migrate/20260311000001_add_requires_approval_to_submissions.rb
@@ -4,5 +4,6 @@ class AddRequiresApprovalToSubmissions < ActiveRecord::Migration[7.2]
   def change
     add_column :submissions, :requires_approval, :boolean, default: false, null: false
     add_column :submissions, :approved_at, :datetime
+    add_index :submissions, :approved_at
   end
 end

--- a/db/migrate/20260311000001_add_requires_approval_to_submissions.rb
+++ b/db/migrate/20260311000001_add_requires_approval_to_submissions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddRequiresApprovalToSubmissions < ActiveRecord::Migration[7.2]
+  def change
+    add_column :submissions, :requires_approval, :boolean, default: false, null: false
+    add_column :submissions, :approved_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_06_171605) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_11_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -327,6 +327,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_06_171605) do
     t.integer "account_id", null: false
     t.datetime "expire_at"
     t.text "name"
+    t.boolean "requires_approval", default: false, null: false
+    t.datetime "approved_at"
     t.index ["account_id", "id"], name: "index_submissions_on_account_id_and_id"
     t.index ["account_id", "template_id", "id"], name: "index_submissions_on_account_id_and_template_id_and_id", where: "(archived_at IS NULL)"
     t.index ["account_id", "template_id", "id"], name: "index_submissions_on_account_id_and_template_id_and_id_archived", where: "(archived_at IS NOT NULL)"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -332,6 +332,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_11_000001) do
     t.index ["account_id", "id"], name: "index_submissions_on_account_id_and_id"
     t.index ["account_id", "template_id", "id"], name: "index_submissions_on_account_id_and_template_id_and_id", where: "(archived_at IS NULL)"
     t.index ["account_id", "template_id", "id"], name: "index_submissions_on_account_id_and_template_id_and_id_archived", where: "(archived_at IS NOT NULL)"
+    t.index ["approved_at"], name: "index_submissions_on_approved_at"
     t.index ["created_by_user_id"], name: "index_submissions_on_created_by_user_id"
     t.index ["slug"], name: "index_submissions_on_slug", unique: true
     t.index ["template_id"], name: "index_submissions_on_template_id"

--- a/lib/submissions/create_from_submitters.rb
+++ b/lib/submissions/create_from_submitters.rb
@@ -23,6 +23,7 @@ module Submissions
                                               preferences: set_submission_preferences,
                                               name: with_template ? attrs[:name] : (attrs[:name] || template.name),
                                               expire_at:,
+                                              requires_approval: params[:requires_approval],
                                               template_submitters: [], submitters_order:)
 
         template_submitters = template.submitters.deep_dup

--- a/lib/submissions/create_from_submitters.rb
+++ b/lib/submissions/create_from_submitters.rb
@@ -23,7 +23,7 @@ module Submissions
                                               preferences: set_submission_preferences,
                                               name: with_template ? attrs[:name] : (attrs[:name] || template.name),
                                               expire_at:,
-                                              requires_approval: params[:requires_approval],
+                                              requires_approval: params[:requires_approval] || false,
                                               template_submitters: [], submitters_order:)
 
         template_submitters = template.submitters.deep_dup

--- a/lib/submissions/generate_audit_trail.rb
+++ b/lib/submissions/generate_audit_trail.rb
@@ -388,7 +388,7 @@ module Submissions
       composer.text(I18n.t('event_log'), font_size: 12, padding: [10, 0, 20, 0])
 
       events_data = submission.submission_events.sort_by(&:event_timestamp).filter_map do |event|
-        next if event.event_type.in?(%w[bounce_email complaint_email form_update])
+        next if event.event_type.in?(%w[bounce_email complaint_email])
 
         submitter = submission.submitters.find { |e| e.id == event.submitter_id }
         submitter_name =

--- a/lib/submissions/generate_audit_trail.rb
+++ b/lib/submissions/generate_audit_trail.rb
@@ -388,7 +388,7 @@ module Submissions
       composer.text(I18n.t('event_log'), font_size: 12, padding: [10, 0, 20, 0])
 
       events_data = submission.submission_events.sort_by(&:event_timestamp).filter_map do |event|
-        next if event.event_type.in?(%w[bounce_email complaint_email])
+        next if event.event_type.in?(%w[bounce_email complaint_email form_update])
 
         submitter = submission.submitters.find { |e| e.id == event.submitter_id }
         submitter_name =

--- a/lib/submissions/serialize_for_api.rb
+++ b/lib/submissions/serialize_for_api.rb
@@ -24,6 +24,7 @@ module Submissions
 
       json = submission.as_json(SERIALIZE_PARAMS)
 
+      json['submission_id'] = submission.id
       json['external_account_id'] = submission.account&.external_account_id
       json['created_by_user'] ||= nil
 

--- a/lib/submitters/serialize_for_api.rb
+++ b/lib/submitters/serialize_for_api.rb
@@ -51,7 +51,7 @@ module Submitters
     def serialize_events(events)
       events.map do |event|
         event.as_json(only: %i[id submitter_id event_type event_timestamp])
-             .merge('data' => event.data.slice('reason', 'firstname', 'lastname', 'method', 'country'))
+             .merge('data' => event.data.slice('reason', 'firstname', 'lastname', 'method', 'country', 'changes'))
       end
     end
   end

--- a/lib/submitters/serialize_for_webhook.rb
+++ b/lib/submitters/serialize_for_webhook.rb
@@ -40,7 +40,8 @@ module Submitters
                         methods: %i[folder_name]
                       ),
                       'submission' => {
-                        **submitter.submission.slice(:id, :audit_log_url, :combined_document_url, :created_at),
+                        **submitter.submission.slice(:id, :audit_log_url, :combined_document_url, :created_at,
+                                                     :requires_approval),
                         status: build_submission_status(submitter.submission),
                         url: r.submissions_preview_url(submitter.submission.slug, **Docuseal.default_url_options)
                       })

--- a/lib/tasks/webhooks.rake
+++ b/lib/tasks/webhooks.rake
@@ -33,7 +33,8 @@ namespace :webhooks do
     url = 'http://localhost:3000/api/docuseal/events'
     secret = { 'X-CareerPlug-Secret' => 'development_webhook_secret' }
     sha1 = Digest::SHA1.hexdigest(url)
-    account_events = %w[form.viewed form.started form.completed form.declined template.preferences_updated]
+    account_events = %w[form.started form.completed submission.completed
+                        form.changes_requested template.preferences_updated]
     partnership_events = %w[template.preferences_updated]
 
     created = 0
@@ -70,5 +71,25 @@ namespace :webhooks do
     end
 
     puts "Done: #{created} created, #{updated} updated"
+  end
+
+  desc 'Backfill account webhook URLs to include required ATS events'
+  task backfill_account_events: :environment do
+    required_events = %w[form.started form.completed submission.completed
+                         form.changes_requested template.preferences_updated]
+
+    updated = 0
+
+    WebhookUrl.where(partnership_id: nil).find_each do |webhook_url|
+      missing = required_events - webhook_url.events
+
+      next if missing.empty?
+
+      webhook_url.update!(events: (webhook_url.events + missing).uniq)
+      updated += 1
+      puts "Updated account_id=#{webhook_url.account_id} id=#{webhook_url.id}: added #{missing.join(', ')}"
+    end
+
+    puts "Done: #{updated} webhook URL(s) updated"
   end
 end

--- a/spec/jobs/process_submitter_completion_job_spec.rb
+++ b/spec/jobs/process_submitter_completion_job_spec.rb
@@ -46,6 +46,22 @@ RSpec.describe ProcessSubmitterCompletionJob do
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
 
+    context 'when submission requires approval' do
+      let(:webhook) { create(:webhook_url, account:, events: ['submission.completed']) }
+      let(:submission) { create(:submission, template:, created_by_user: user, requires_approval: true) }
+
+      before do
+        webhook
+        submission.submitters.update_all(completed_at: Time.current)
+      end
+
+      it 'does not enqueue submission.completed webhook' do
+        expect do
+          described_class.new.perform('submitter_id' => submitter.id)
+        end.not_to change(SendSubmissionCompletedWebhookRequestJob.jobs, :size)
+      end
+    end
+
     context 'when all submitters are completed' do
       let(:submitter2) { create(:submitter, submission:, uuid: SecureRandom.uuid, completed_at: Time.current) }
 

--- a/spec/lib/submissions/create_from_submitters_spec.rb
+++ b/spec/lib/submissions/create_from_submitters_spec.rb
@@ -51,6 +51,33 @@ RSpec.describe Submissions::CreateFromSubmitters do
     end
   end
 
+  describe 'requires_approval' do
+    it 'persists requires_approval from params onto the submission' do
+      submissions = described_class.call(
+        template:,
+        user:,
+        submissions_attrs: [{ 'submitters' => submitter_attrs }.with_indifferent_access],
+        source: :api,
+        submitters_order: 'simultaneous',
+        params: { requires_approval: true }
+      )
+
+      expect(submissions.first.requires_approval).to be(true)
+    end
+
+    it 'defaults requires_approval to false when not provided' do
+      submissions = described_class.call(
+        template:,
+        user:,
+        submissions_attrs: [{ 'submitters' => submitter_attrs }.with_indifferent_access],
+        source: :api,
+        submitters_order: 'simultaneous'
+      )
+
+      expect(submissions.first.requires_approval).to be(false)
+    end
+  end
+
   describe 'single_sided skipping' do
     before do
       manager_uuid = template.submitters[1]['uuid']

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -78,10 +78,10 @@ RSpec.describe Account do
 
         expect(webhook).to be_present
         expect(webhook.events).to match_array(%w[
-                                                form.viewed
                                                 form.started
                                                 form.completed
-                                                form.declined
+                                                submission.completed
+                                                form.changes_requested
                                                 template.preferences_updated
                                               ])
       end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -28,6 +28,7 @@
 #  index_submissions_on_account_id_and_id                           (account_id,id)
 #  index_submissions_on_account_id_and_template_id_and_id           (account_id,template_id,id) WHERE (archived_at IS NULL)
 #  index_submissions_on_account_id_and_template_id_and_id_archived  (account_id,template_id,id) WHERE (archived_at IS NOT NULL)
+#  index_submissions_on_approved_at                                 (approved_at)
 #  index_submissions_on_created_by_user_id                          (created_by_user_id)
 #  index_submissions_on_slug                                        (slug) UNIQUE
 #  index_submissions_on_template_id                                 (template_id)

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -1,5 +1,42 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: submissions
+#
+#  id                  :bigint           not null, primary key
+#  approved_at         :datetime
+#  archived_at         :datetime
+#  expire_at           :datetime
+#  name                :text
+#  preferences         :text             not null
+#  requires_approval   :boolean          default(FALSE), not null
+#  slug                :string           not null
+#  source              :string           not null
+#  submitters_order    :string           not null
+#  template_fields     :text
+#  template_schema     :text
+#  template_submitters :text
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  account_id          :integer          not null
+#  created_by_user_id  :integer
+#  template_id         :integer
+#
+# Indexes
+#
+#  index_submissions_on_account_id_and_id                           (account_id,id)
+#  index_submissions_on_account_id_and_template_id_and_id           (account_id,template_id,id) WHERE (archived_at IS NULL)
+#  index_submissions_on_account_id_and_template_id_and_id_archived  (account_id,template_id,id) WHERE (archived_at IS NOT NULL)
+#  index_submissions_on_created_by_user_id                          (created_by_user_id)
+#  index_submissions_on_slug                                        (slug) UNIQUE
+#  index_submissions_on_template_id                                 (template_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (created_by_user_id => users.id)
+#  fk_rails_...  (template_id => templates.id)
+#
 RSpec.describe Submission do
   let(:account) { create(:account) }
   let(:user) { create(:user, account:) }

--- a/spec/models/submitter_spec.rb
+++ b/spec/models/submitter_spec.rb
@@ -134,93 +134,30 @@ RSpec.describe Submitter do
   end
 
   describe '#export_submission_on_status_change' do
-    let(:export_location) { create(:export_location, :with_submissions_endpoint) }
-    let(:export_service) { instance_double(ExportSubmissionService) }
-
+    # CP-12761: ExportSubmissionService is disabled - submission sync migrated to webhooks.
+    # These tests verify the service is not called on any status change.
     before do
-      allow(ExportLocation).to receive(:default_location).and_return(export_location)
-      allow(ExportSubmissionService).to receive(:new).with(submission).and_return(export_service)
-      allow(export_service).to receive(:call).and_return(true)
+      allow(ExportSubmissionService).to receive(:new)
     end
 
-    context 'when status-related field changes' do
-      it 'calls ExportSubmissionService when completed_at changes' do
-        submitter.update!(completed_at: Time.current)
-        expect(ExportSubmissionService).to have_received(:new).with(submission)
-        expect(export_service).to have_received(:call)
-      end
-
-      it 'calls ExportSubmissionService when declined_at changes' do
-        submitter.update!(declined_at: Time.current)
-        expect(ExportSubmissionService).to have_received(:new).with(submission)
-        expect(export_service).to have_received(:call)
-      end
-
-      it 'calls ExportSubmissionService when opened_at changes' do
-        submitter.update!(opened_at: Time.current)
-        expect(ExportSubmissionService).to have_received(:new).with(submission)
-        expect(export_service).to have_received(:call)
-      end
-
-      it 'calls ExportSubmissionService when sent_at changes' do
-        submitter.update!(sent_at: Time.current)
-        expect(ExportSubmissionService).to have_received(:new).with(submission)
-        expect(export_service).to have_received(:call)
-      end
+    it 'does not call ExportSubmissionService when completed_at changes' do
+      submitter.update!(completed_at: Time.current)
+      expect(ExportSubmissionService).not_to have_received(:new)
     end
 
-    context 'when non-status field changes' do
-      it 'does not call ExportSubmissionService when email changes' do
-        submitter.update!(email: 'new@example.com')
-        expect(ExportSubmissionService).not_to have_received(:new)
-        expect(export_service).not_to have_received(:call)
-      end
-
-      it 'does not call ExportSubmissionService when name changes' do
-        submitter.update!(name: 'New Name')
-        expect(ExportSubmissionService).not_to have_received(:new)
-        expect(export_service).not_to have_received(:call)
-      end
+    it 'does not call ExportSubmissionService when declined_at changes' do
+      submitter.update!(declined_at: Time.current)
+      expect(ExportSubmissionService).not_to have_received(:new)
     end
 
-    context 'when export service raises an error' do
-      before do
-        allow(export_service).to receive(:call).and_raise(StandardError.new('Export failed'))
-        allow(Rails.logger).to receive(:error)
-      end
-
-      it 'logs the error and does not re-raise' do
-        expect { submitter.update!(completed_at: Time.current) }.not_to raise_error
-        expect(Rails.logger).to have_received(:error).with(
-          'Failed to export submission on status change: Export failed'
-        )
-      end
+    it 'does not call ExportSubmissionService when opened_at changes' do
+      submitter.update!(opened_at: Time.current)
+      expect(ExportSubmissionService).not_to have_received(:new)
     end
 
-    context 'when ExportLocation.default_location returns nil' do
-      before do
-        allow(ExportLocation).to receive(:default_location).and_return(nil)
-        allow(export_service).to receive(:call).and_return(false)
-      end
-
-      it 'calls ExportSubmissionService but service handles nil export location' do
-        submitter.update!(completed_at: Time.current)
-        expect(ExportSubmissionService).to have_received(:new).with(submission)
-        expect(export_service).to have_received(:call)
-      end
-    end
-
-    context 'when export location has no submissions_endpoint' do
-      before do
-        allow(export_location).to receive(:submissions_endpoint).and_return(nil)
-        allow(export_service).to receive(:call).and_return(false)
-      end
-
-      it 'calls ExportSubmissionService but service handles missing endpoint' do
-        submitter.update!(completed_at: Time.current)
-        expect(ExportSubmissionService).to have_received(:new).with(submission)
-        expect(export_service).to have_received(:call)
-      end
+    it 'does not call ExportSubmissionService when sent_at changes' do
+      submitter.update!(sent_at: Time.current)
+      expect(ExportSubmissionService).not_to have_received(:new)
     end
   end
 

--- a/spec/models/template_spec.rb
+++ b/spec/models/template_spec.rb
@@ -1,5 +1,46 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: templates
+#
+#  id                   :bigint           not null, primary key
+#  archived_at          :datetime
+#  external_data_fields :text
+#  fields               :text             not null
+#  name                 :string           not null
+#  preferences          :text             not null
+#  schema               :text             not null
+#  shared_link          :boolean          default(FALSE), not null
+#  slug                 :string           not null
+#  source               :text             not null
+#  submitters           :text             not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  account_id           :integer
+#  author_id            :integer          not null
+#  external_id          :string
+#  folder_id            :integer          not null
+#  partnership_id       :bigint
+#
+# Indexes
+#
+#  index_templates_on_account_id                       (account_id)
+#  index_templates_on_account_id_and_folder_id_and_id  (account_id,folder_id,id) WHERE (archived_at IS NULL)
+#  index_templates_on_account_id_and_id_archived       (account_id,id) WHERE (archived_at IS NOT NULL)
+#  index_templates_on_author_id                        (author_id)
+#  index_templates_on_external_id                      (external_id)
+#  index_templates_on_folder_id                        (folder_id)
+#  index_templates_on_partnership_id                   (partnership_id)
+#  index_templates_on_slug                             (slug) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (account_id => accounts.id)
+#  fk_rails_...  (author_id => users.id)
+#  fk_rails_...  (folder_id => template_folders.id)
+#  fk_rails_...  (partnership_id => partnerships.id)
+#
 RSpec.describe Template do
   let(:account) { create(:account) }
   let(:user) { create(:user, account:) }

--- a/spec/requests/api_submitters_approve_spec.rb
+++ b/spec/requests/api_submitters_approve_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+describe 'API Submitters Approve' do
+  let(:account) { create(:account) }
+  let(:user) { create(:user, account:) }
+  let(:template) { create(:template, account:, author: user) }
+  let(:submission) do
+    create(:submission, template:, account:, created_by_user: user, requires_approval: true)
+  end
+  let(:submitter) do
+    create(
+      :submitter,
+      submission:,
+      account:,
+      completed_at: 1.hour.ago,
+      uuid: template.submitters.first['uuid']
+    )
+  end
+
+  describe 'POST /api/submitters/:slug/approve' do
+    context 'when authenticated with a valid token' do
+      it 'sets approved_at on the submission' do
+        expect do
+          post "/api/submitters/#{submitter.slug}/approve",
+               headers: { 'x-auth-token': user.access_token.token }
+        end.to change { submission.reload.approved_at }.from(nil)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'does not enqueue any webhooks' do
+        create(:webhook_url, account:, events: ['submission.completed'])
+
+        expect do
+          post "/api/submitters/#{submitter.slug}/approve",
+               headers: { 'x-auth-token': user.access_token.token }
+        end.not_to change(SendSubmissionCompletedWebhookRequestJob.jobs, :size)
+      end
+
+      it 'is idempotent when already approved' do
+        submission.update!(approved_at: 1.hour.ago)
+        original_approved_at = submission.approved_at
+
+        post "/api/submitters/#{submitter.slug}/approve",
+             headers: { 'x-auth-token': user.access_token.token }
+
+        expect(submission.reload.approved_at).to eq(original_approved_at)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when authenticated with a different account token' do
+      let(:other_user) { create(:user, account: create(:account)) }
+
+      it 'returns forbidden' do
+        post "/api/submitters/#{submitter.slug}/approve",
+             headers: { 'x-auth-token': other_user.access_token.token }
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'when unauthenticated' do
+      it 'returns unauthorized' do
+        post "/api/submitters/#{submitter.slug}/approve"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api_submitters_request_changes_spec.rb
+++ b/spec/requests/api_submitters_request_changes_spec.rb
@@ -17,6 +17,19 @@ describe 'API Submitters Request Changes' do
 
   describe 'POST /api/submitters/:slug/request_changes' do
     context 'when authenticated with a valid token' do
+      it 'clears completed_at, sets changes_requested_at, and clears approved_at' do
+        submission.update!(approved_at: 1.hour.ago)
+
+        expect do
+          post "/api/submitters/#{submitter.slug}/request_changes",
+               headers: { 'x-auth-token': user.access_token.token }
+        end.to change { submitter.reload.changes_requested_at }.from(nil)
+           .and change { submitter.reload.completed_at }.to(nil)
+           .and change { submission.reload.approved_at }.to(nil)
+
+        expect(response).to have_http_status(:ok)
+      end
+
       it 'clears completed_at and sets changes_requested_at' do
         expect do
           post "/api/submitters/#{submitter.slug}/request_changes",

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -285,6 +285,7 @@ describe 'Submission API' do
 
     {
       id: submission.id,
+      submission_id: submission.id,
       account_id: submission.account_id,
       external_account_id: submission.account&.external_account_id,
       name: submission.name,
@@ -346,6 +347,7 @@ describe 'Submission API' do
 
     {
       id: submission.id,
+      submission_id: submission.id,
       account_id: submission.account_id,
       external_account_id: submission.account&.external_account_id,
       name: submission.name,


### PR DESCRIPTION
## Summary
Implements the manager approval gate for single-sided Docuseal forms. When a submission is created with `requires_approval: true`, Docuseal suppresses the submission.completed webhook until explicitly approved via the new API endpoint. Dual-sided forms are treated as always `requires_approval: false`.

## Changes                                
#### New API Endpoints
- POST /api/submitters/:slug/approve - Sets `approved_at` on the submission.                                                                                            
- POST /api/submitters/:slug/request_changes - Clears `approved_at` so the re-approval cycle works correctly after a submitter re-completes.

#### Webhook Behavior
- `requires_approval: true` - `form.completed` fires only when the submitter finishes. `submission.completed` is suppressed until approval endpoint is called
- `requires_approval: false` - existing behavior unchanged. `submission.completed` fires immediately when all submitters complete
- Updated default webhook event set: replaced `form.viewed`/`form.declined` with `submission.completed` and `form.changes_requested`
- Added `submission_id` to `submission.completed` payload to route to correct task                  
                                                                                                                                                  
#### Bug Fixes
- Fixed audit trail crash (`I18n::MissingTranslationData`) caused by `form_update` event type having no translation key                                                                                    
- Disabled `ExportSubmissionService` direct POST to ATS (CP-12761) — submission sync now fully handled by webhooks                                  
                                                                                                                                                  
#### Cleanup
- Removed Request Changes button from submissions/show — approval flow is API-only                                                                
- Added backfill_account_events rake task to update existing webhook URLs to the new event set