### PR TITLE
CP-12315 completed and awaiting partial updates

### DIFF
--- a/app/views/submit_form/awaiting.html.erb
+++ b/app/views/submit_form/awaiting.html.erb
@@ -7,7 +7,6 @@
             <%= svg_icon('writing_sign', class: 'w-10 h-10') %>
           </div>
           <div dir="auto">
-            <p class="text-lg font-bold mb-1"><%= @submitter.submission.name || @submitter.submission.template.name %></p>
             <p class="text-sm"><%= t('awaiting_completion_by_the_other_party') %></p>
           </div>
         </div>

--- a/app/views/submit_form/completed.html.erb
+++ b/app/views/submit_form/completed.html.erb
@@ -7,10 +7,14 @@
             <%= svg_icon('writing_sign', class: 'w-10 h-10') %>
           </div>
           <div>
-            <p dir="auto" class="text-lg font-bold mb-1"><%= @submitter.submission.name || @submitter.submission.template.name %></p>
-            <p dir="auto" class="text-sm">
-              <%= t(@submitter.with_signature_fields? ? 'signed_on_time' : 'completed_on_time', time: l(@submitter.completed_at.to_date, format: :long)) %>
-            </p>
+            <% if @submitter.submission.requires_approval? && @submitter.submission.approved_at.nil? %>
+              <p dir="auto" class="text-sm font-bold mb-1"><%= t('submitted_on_time', time: l(@submitter.completed_at.to_date, format: :long)) %></p>
+              <p dir="auto" class="text-sm"><%= t('awaiting_manager_approval') %></p>
+            <% else %>
+              <p dir="auto" class="text-sm">
+                <%= t(@submitter.with_signature_fields? ? 'signed_on_time' : 'completed_on_time', time: l(@submitter.completed_at.to_date, format: :long)) %>
+              </p>
+            <% end %>
           </div>
         </div>
       </div>
@@ -19,3 +23,4 @@
     </div>
   </div>
 </div>
+<%= render 'shared/attribution', link_path: '/start', account: @submitter.account %>

--- a/config/locales/i18n.yml
+++ b/config/locales/i18n.yml
@@ -130,6 +130,8 @@ en: &en
   you_have_been_invited_to_submit_a_form: You have been invited to submit a form
   signed_on_time: 'Signed on %{time}'
   completed_on_time: 'Completed on %{time}'
+  submitted_on_time: 'Submitted on %{time}'
+  awaiting_manager_approval: 'Awaiting manager approval'
   document_has_been_signed_already: Document has been signed already
   form_has_been_submitted_already: Form has been submitted already
   send_copy_to_email: Send copy to Email


### PR DESCRIPTION
## Summary

- Remove form name from `completed` and `awaiting` partials. The name is set on create and not synced on edits, so it can show inconsistent data.
- Update `completed` copy to show **"Submitted on {date} / Awaiting manager approval"** when `requires_approval: true` and not yet approved.
- Add DocuSeal footer attribution to `completed.html.erb` for consistency with other states

Before:
<img width="1280" height="1243" alt="image" src="https://github.com/user-attachments/assets/39b186a1-f961-4497-93a2-f5902bcd713a" />

After - Awaiting Approval Status: 
<img width="1279" height="646" alt="image" src="https://github.com/user-attachments/assets/1b0ff192-3511-4112-afae-4c0393baad9c" />

After - Awaiting other party to complete their side:
<img width="1276" height="502" alt="image" src="https://github.com/user-attachments/assets/14f13f75-e452-4191-b65b-c6722317ba28" />

