### PR TITLE
CP-13299 Fix lazy preview caching

### DIFF
--- a/lib/templates/process_document.rb
+++ b/lib/templates/process_document.rb
@@ -204,7 +204,7 @@ module Templates
     def generate_pdf_preview_from_file(attachment, file_path, page_number)
       doc = Pdfium::Document.open_file(file_path)
 
-      blob = build_and_upload_blob(doc, page_number, '.jpeg')
+      blob = build_and_upload_blob(doc, page_number, '.jpg')
 
       ApplicationRecord.no_touching do
         ActiveStorage::Attachment.create!(

--- a/spec/lib/templates/process_document_spec.rb
+++ b/spec/lib/templates/process_document_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+describe Templates::ProcessDocument do
+  describe '.generate_pdf_preview_from_file' do
+    let(:account) { create(:account) }
+    let(:user) { create(:user, account:) }
+    let(:template) { create(:template, account:, author: user, attachment_count: 0) }
+    let(:attachment) do
+      blob = ActiveStorage::Blob.create_and_upload!(
+        io: Rails.root.join('spec/fixtures/sample-document.pdf').open,
+        filename: 'sample-document.pdf',
+        content_type: 'application/pdf'
+      )
+      ActiveStorage::Attachment.create!(blob: blob, name: :documents, record: template)
+    end
+    let(:file_path) { ActiveStorage::Blob.service.path_for(attachment.key) }
+
+    it 'saves the preview blob under a filename the PreviewDocumentPageController cache lookup matches' do
+      described_class.generate_pdf_preview_from_file(attachment, file_path, 0)
+
+      cached = attachment.preview_images.joins(:blob)
+                         .find_by(blob: { filename: ['0.png', '0.jpg'] })
+
+      expect(cached).not_to be_nil
+    end
+  end
+end


### PR DESCRIPTION
### Overview
 Fixes a bug in production where any page after `15` was rendering intermittently.

  Pages beyond `MAX_NUMBER_OF_PAGES_PROCESSED` (15) are rendered on-demand
  by `PreviewDocumentPageController#show`. Before regenerating, the
  controller looks for an existing cached blob:

  ```ruby
  preview_image = attachment.preview_images.joins(:blob)
                            .find_by(blob: { filename: ["#{params[:id]}.png", "#{params[:id]}.jpg"] })

  But Templates::ProcessDocument.generate_pdf_preview_from_file was
  saving the blob as "#{page_number}.jpeg" — .jpeg ≠ .jpg, so the
  cache lookup never matched. Every request to /preview/<token>/<n>.jpg
  re-downloaded the source PDF, re-rendered the page through Pdfium, and
  created a duplicate ActiveStorage::Attachment.

  Impact in production

  - Editor shows broken images for pages 16+ when Pdfium fails under repeated load.
  - Duplicate ActiveStorage::Attachment records pile up (no dedup on create!).
  - Wasted S3 upload + Pdfium CPU on every editor render of pages 16+.

###  Change

  One-line fix: save lazy-generated previews as .jpg so the
  controller's cache lookup matches and redirects to the existing blob
  on subsequent requests.

### Test

  Added spec/lib/templates/process_document_spec.rb running the exact
  controller-side find_by against a freshly generated preview. Locks
  in the filename contract so a future regression to .jpeg (or any
  other non-matching extension) fails immediately.

  Manually verified the failure mode by reverting the fix locally — spec
  fails with got: nil from the cache lookup.

  Two notes if you want to tweak before pushing:
  - The triple-backtick block in the description renders nicely on GitHub but you may want to drop it if your PR template is bare text.
  - This fix doesn't address the other two issues we discussed (nil-blob 500s, partial-tempfile corruption). Worth a one-liner at the end of the description like *"Follow-ups (separate tickets): nil-blob handling in controller, tempfile completeness check"* — so reviewers don't think those are out of scope by omission.