### PR TITLE
CP-13195 - Disable "Copy to All Pages" field action

### DIFF
--- a/app/javascript/template_builder/field_settings.vue
+++ b/app/javascript/template_builder/field_settings.vue
@@ -458,6 +458,8 @@
       </a>
     </li>
   </template>
+  <!-- Copy to All Pages disabled -->
+  <!--
   <li v-if="field.areas?.length === 1 && ['date', 'signature', 'initials', 'text', 'cells', 'stamp'].includes(field.type)">
     <a
       href="#"
@@ -471,10 +473,11 @@
       {{ t('copy_to_all_pages') }}
     </a>
   </li>
+  -->
 </template>
 
 <script>
-import { IconRouteAltLeft, IconTypography, IconShape, IconX, IconMathFunction, IconNewSection, IconInfoCircle, IconCopy } from '@tabler/icons-vue'
+import { IconRouteAltLeft, IconTypography, IconShape, IconX, IconMathFunction, IconNewSection, IconInfoCircle } from '@tabler/icons-vue'
 
 export default {
   name: 'FieldSettings',
@@ -483,7 +486,6 @@ export default {
     IconInfoCircle,
     IconMathFunction,
     IconRouteAltLeft,
-    IconCopy,
     IconNewSection,
     IconTypography,
     IconX


### PR DESCRIPTION
CP-13195

# Overview
Remove the "Copy to All Pages" menu option from the field settings dropdown. The menu item and its IconCopy import are commented out.

## Screenshot
<img width="243" height="429" alt="Screenshot 2026-05-28 at 4 46 29 PM" src="https://github.com/user-attachments/assets/b6898b83-0756-4699-b873-f109b637dc95" />
