### PR TITLE
CP-12559 - Add Pendo integration partial

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
     <%= stylesheet_pack_tag 'application', media: 'all' %>
     <%= render 'shared/posthog' if ENV['POSTHOG_TOKEN'] %>
     <%= render 'shared/plausible' if !signed_in? && ENV['PLAUSIBLE_DOMAIN'] %>
+    <%= render 'shared/pendo' if ENV['PENDO_API_KEY'] %>
   </head>
   <body>
     <turbo-frame id="modal"></turbo-frame>

--- a/app/views/shared/_pendo.html.erb
+++ b/app/views/shared/_pendo.html.erb
@@ -1,0 +1,17 @@
+<script>
+  (function(apiKey){
+    (function(p,e,n,d,o){var v,w,x,y,z;o=p[d]=p[d]||{};o._q=[];
+    v=['initialize','identify','updateOptions','pageLoad'];for(w=0,x=v.length;w<x;++w)(function(m){
+      o[m]=o[m]||function(){o._q[m===v[0]?'unshift':'push']([m].concat([].slice.call(arguments,0)));};})(v[w]);
+    y=e.createElement(n);y.async=!0;y.src='https://cdn.pendo.io/agent/static/'+apiKey+'/pendo.js';
+    z=e.getElementsByTagName(n)[0];z.parentNode.insertBefore(y,z);})(window,document,'script','pendo');
+    <% if signed_in? %>
+      pendo.initialize({
+        visitor: { id: '<%= current_user.external_user_id || current_user.id %>' },
+        account:  { id: '<%= current_account.external_account_id || current_account.id %>' }
+      });
+    <% else %>
+      pendo.initialize({});
+    <% end %>
+  })('<%= ENV.fetch('PENDO_API_KEY', nil) %>');
+</script>

--- a/lib/templates/process_document.rb
+++ b/lib/templates/process_document.rb
@@ -94,7 +94,7 @@ module Templates
         attachment.save!
       end
 
-      generate_document_preview_images(attachment, data, (0..number_of_pages - 1))
+      generate_document_preview_images(attachment, data, 0..number_of_pages - 1)
     end
 
     def generate_document_preview_images(attachment, data, range, concurrency: CONCURRENCY)
@@ -196,6 +196,5 @@ module Templates
         pdf_fields
       end
     end
-
   end
 end


### PR DESCRIPTION
CP-12559

# Overview
Add a new shared partial `_pendo.html.erb` that loads the Pendo agent script and initializes it with visitor and account data for signed-in users, or empty initialization for anonymous sessions.
The partial is conditionally rendered in the application layout when the `PENDO_API_KEY` environment variable is set.