### PR TITLE
CP-12437 - Harden Airbrake and New Relic config for production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem 'twitter_cldr', require: false
 gem 'tzinfo-data'
 
 gem 'airbrake'
-gem 'newrelic_rpm'
+gem 'newrelic_rpm', '~> 9.24.0'
 
 group :development, :test do
   gem 'better_html'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,7 +343,7 @@ GEM
       timeout
     net-smtp (0.5.0)
       net-protocol
-    newrelic_rpm (9.17.0)
+    newrelic_rpm (9.24.0)
     nio4r (2.7.4)
     nokogiri (1.18.8)
       mini_portile2 (~> 2.8.2)
@@ -629,7 +629,7 @@ DEPENDENCIES
   jwt
   letter_opener_web
   lograge
-  newrelic_rpm
+  newrelic_rpm (~> 9.24.0)
   oj
   pagy
   pg

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -6,6 +6,22 @@ unless ENV['DOCKER_BUILD'] || ENV['CI_BUILD']
     config.project_id = ENV['AIRBRAKE_ID'] # rubocop:disable Style/FetchEnvVar
     config.environment = Rails.env
     config.ignore_environments = %w[development test]
-    config.root_directory = '/var/cpd/app'
+    config.root_directory = Rails.root.to_s
+    config.blocklist_keys = Rails.application.config.filter_parameters
+  end
+
+  AIRBRAKE_IGNORE = [
+    'AbstractController::ActionNotFound',
+    'ActionController::InvalidAuthenticityToken',
+    'ActionController::RoutingError',
+    'ActionController::UnknownAction',
+    'ActionController::UnknownFormat',
+    'ActiveRecord::RecordNotFound',
+    'SignalException',
+    'Sidekiq::Shutdown'
+  ].freeze
+
+  Airbrake.add_filter do |notice|
+    notice.ignore! if notice[:errors].any? { |error| AIRBRAKE_IGNORE.include?(error[:type]) }
   end
 end

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -111,7 +111,8 @@ common: &default_settings
 
   # Prefix of attributes to include in all destinations. Allows * as wildcard at
   # end.
-  # attributes.include: []
+  attributes.include:
+    - job.sidekiq.args.*
 
   # If true, enables an audit log which logs communications with the New Relic
   # collector.
@@ -1112,6 +1113,6 @@ staging:
 
 production:
   <<: *default_settings
-  app_name: <%= ENV['NEWRELIC_APP_NAME'] %> Production
+  app_name: Docuseal Production - <%= ENV['ENV_NAME'] %>
   monitor_mode: <%= ENV['NEWRELIC_MONITOR_MODE'].presence || true %>
-  distributed_tracing.enabled: false
+  distributed_tracing.enabled: true

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -111,8 +111,7 @@ common: &default_settings
 
   # Prefix of attributes to include in all destinations. Allows * as wildcard at
   # end.
-  attributes.include:
-    - job.sidekiq.args.*
+  # attributes.include: []
 
   # If true, enables an audit log which logs communications with the New Relic
   # collector.


### PR DESCRIPTION
- Fix Airbrake root_directory from /var/cpd/app to Rails.root.to_s
- Add blocklist_keys to prevent sensitive params in error reports
- Add AIRBRAKE_IGNORE filter for RoutingError, RecordNotFound, etc.
- Bump newrelic_rpm from 9.17.0 to 9.24.0 (match ATS)
- Enable distributed_tracing in production
- Include ENV_NAME in production app_name for instance differentiation