### PR TITLE
CP-14026 - Prevent horizontal overflow on mobile and adjust bottom padding

### DIFF
--- a/app/javascript/submission_form/form.vue
+++ b/app/javascript/submission_form/form.vue
@@ -943,9 +943,10 @@ export default {
       const style = { backgroundColor: this.backgroundColor }
 
       if (this.isMobile) {
+        style.overflowX = 'hidden'
         style.minHeight = '100dvh'
         style.paddingTop = 'max(env(safe-area-inset-top), 1.5rem)'
-        style.paddingBottom = 'max(env(safe-area-inset-bottom), 1.5rem)'
+        style.paddingBottom = '6rem'
       }
 
       return style


### PR DESCRIPTION
CP-14026

## Overview
Set overflowX to hidden on mobile views to prevent unintended horizontal scrolling. Replace the dynamic safe-area-inset-bottom padding with a fixed 6rem value for consistent visual spacing.