### PR TITLE
CP-14119 - Keep submit form expanded when ATS requests expand=true

### DIFF
--- a/app/controllers/submit_form_controller.rb
+++ b/app/controllers/submit_form_controller.rb
@@ -39,6 +39,10 @@ class SubmitFormController < ApplicationController
     # Fetch prefill values if available
     @prefill_values = fetch_prefill_values_if_available
 
+    # When the URL contains expand=true, keep the form panel expanded on desktop
+    # instead of auto-minimizing when the current field is signature/initials/file/image.
+    @expand = params[:expand] == 'true'
+
     @attachments_index = build_attachments_index(submission)
 
     return unless @form_configs[:prefill_signature]

--- a/app/views/submit_form/show.html.erb
+++ b/app/views/submit_form/show.html.erb
@@ -68,7 +68,7 @@
 <div class="fixed bottom-0 w-full z-20 md:h-0">
   <div class="mx-auto" style="max-width: 1000px">
     <div class="relative md:mx-32">
-      <%= render 'submit_form/submission_form', attachments_index: @attachments_index, submitter: @submitter, signature_attachment: @signature_attachment, configs: @form_configs, dry_run: local_assigns[:dry_run], expand: local_assigns[:expand], scroll_padding: local_assigns.fetch(:scroll_padding, '-110px'), schema:, values: values %>
+      <%= render 'submit_form/submission_form', attachments_index: @attachments_index, submitter: @submitter, signature_attachment: @signature_attachment, configs: @form_configs, dry_run: local_assigns[:dry_run], expand: @expand || local_assigns[:expand], scroll_padding: local_assigns.fetch(:scroll_padding, '-110px'), schema:, values: values %>
     </div>
   </div>
 </div>

--- a/spec/system/signing_form_spec.rb
+++ b/spec/system/signing_form_spec.rb
@@ -342,6 +342,33 @@ RSpec.describe 'Signing Form' do
     end
   end
 
+  context 'when the signature step is opened with expand=true' do
+    let(:template) { create(:template, account:, author:, only_field_types: %w[signature]) }
+    let(:submission) { create(:submission, template:) }
+    let(:submitter) do
+      create(:submitter, submission:, uuid: template.submitters.first['uuid'], account:)
+    end
+
+    it 'keeps the form panel expanded without needing to click Sign Now' do
+      visit submit_form_path(slug: submitter.slug, expand: 'true')
+
+      # The expand (Sign Now) button is absent because the panel is already open
+      expect(page).not_to have_selector('#expand_form_button')
+      expect(page).to have_selector('#form_container')
+
+      # The signature canvas is directly accessible
+      draw_canvas
+      click_button 'Sign and Complete'
+
+      expect(page).to have_content('Document has been signed!')
+
+      submitter.reload
+
+      expect(submitter.completed_at).to be_present
+      expect(field_value(submitter, 'Signature')).to be_present
+    end
+  end
+
   context 'when the multiple choice step' do
     let(:template) { create(:template, account:, author:, only_field_types: %w[multiple]) }
     let(:submission) { create(:submission, template:) }


### PR DESCRIPTION
CP-14119

## What
The submit form now respects an `expand=true` URL parameter. When present, the form panel stays open on desktop instead of auto-minimizing when the first field is a signature, initials, file, or image.

## Why
Employees opening a DocuSeal task on desktop saw only the PDF and a small "Sign Now" button — the input panel was collapsed by the auto-minimize behavior. Several read this as "no fields on the form" and could not complete the task. The ATS now sends expand=true on the fillable URL so the fields are visible immediately.

## How to test
1. Create a template whose first field is a signature.
2. Open the submitter link with `?expand=true` on a desktop-width viewport.
3. Confirm the form panel is visible and the signature canvas is usable without clicking "Sign Now" first.